### PR TITLE
🌱 Move ProviderServiceAccount & ServiceDiscovery controller to supervisor package

### DIFF
--- a/controllers/vmware/controllers_suite_test.go
+++ b/controllers/vmware/controllers_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package vmware
 
 import (
 	"fmt"
@@ -46,9 +46,9 @@ func TestControllers(t *testing.T) {
 
 	reporterConfig := types.NewDefaultReporterConfig()
 	if artifactFolder, exists := os.LookupEnv("ARTIFACTS"); exists {
-		reporterConfig.JUnitReport = filepath.Join(artifactFolder, "junit.ginkgo.controllers.xml")
+		reporterConfig.JUnitReport = filepath.Join(artifactFolder, "junit.ginkgo.controllers_vmware.xml")
 	}
-	RunSpecs(t, "Controller Suite", reporterConfig)
+	RunSpecs(t, "VMware Controller Suite", reporterConfig)
 }
 
 var (
@@ -101,20 +101,11 @@ func setup() {
 		panic(fmt.Sprintf("unable to create ClusterCacheReconciler controller: %v", err))
 	}
 
-	if err := AddClusterControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, false, controllerOpts); err != nil {
-		panic(fmt.Sprintf("unable to setup VsphereCluster controller: %v", err))
+	if err := AddServiceAccountProviderControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, tracker, controllerOpts); err != nil {
+		panic(fmt.Sprintf("unable to setup ServiceAccount controller: %v", err))
 	}
-	if err := AddMachineControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, false, controllerOpts); err != nil {
-		panic(fmt.Sprintf("unable to setup VsphereMachine controller: %v", err))
-	}
-	if err := AddVMControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, tracker, controllerOpts); err != nil {
-		panic(fmt.Sprintf("unable to setup VsphereVM controller: %v", err))
-	}
-	if err := AddVsphereClusterIdentityControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, controllerOpts); err != nil {
-		panic(fmt.Sprintf("unable to setup VSphereClusterIdentity controller: %v", err))
-	}
-	if err := AddVSphereDeploymentZoneControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, controllerOpts); err != nil {
-		panic(fmt.Sprintf("unable to setup VSphereDeploymentZone controller: %v", err))
+	if err := AddServiceDiscoveryControllerToManager(ctx, testEnv.GetControllerManagerContext(), testEnv.Manager, tracker, controllerOpts); err != nil {
+		panic(fmt.Sprintf("unable to setup SvcDiscovery controller: %v", err))
 	}
 
 	go func() {

--- a/controllers/vmware/serviceaccount_controller.go
+++ b/controllers/vmware/serviceaccount_controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package vmware
 
 import (
 	"context"
@@ -61,7 +61,6 @@ import (
 
 const (
 	kindProviderServiceAccount = "ProviderServiceAccount"
-	systemServiceAccountPrefix = "system.serviceaccount"
 )
 
 // AddServiceAccountProviderControllerToManager adds this controller to the provided manager.

--- a/controllers/vmware/serviceaccount_controller_intg_test.go
+++ b/controllers/vmware/serviceaccount_controller_intg_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package vmware
 
 import (
 	"fmt"

--- a/controllers/vmware/serviceaccount_controller_suite_test.go
+++ b/controllers/vmware/serviceaccount_controller_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package vmware
 
 import (
 	"context"

--- a/controllers/vmware/serviceaccount_controller_unit_test.go
+++ b/controllers/vmware/serviceaccount_controller_unit_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package vmware
 
 import (
 	"context"

--- a/controllers/vmware/servicediscovery_controller.go
+++ b/controllers/vmware/servicediscovery_controller.go
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package vmware
 
 import (
 	"context"
 	"fmt"
 	"net"
 	"net/url"
+	"reflect"
 	"time"
 
 	"github.com/pkg/errors"
@@ -484,4 +485,9 @@ func allClustersRequests(ctx context.Context, c client.Client) []reconcile.Reque
 		requests = append(requests, reconcile.Request{NamespacedName: key})
 	}
 	return requests
+}
+
+func clusterToVMwareInfrastructureMapFunc(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext) handler.MapFunc {
+	gvk := vmwarev1.GroupVersion.WithKind(reflect.TypeOf(&vmwarev1.VSphereCluster{}).Elem().Name())
+	return clusterutilv1.ClusterToInfrastructureMapFunc(ctx, gvk, controllerCtx.Client, &vmwarev1.VSphereCluster{})
 }

--- a/controllers/vmware/servicediscovery_controller_intg_test.go
+++ b/controllers/vmware/servicediscovery_controller_intg_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package vmware
 
 import (
 	"fmt"

--- a/controllers/vmware/servicediscovery_controller_suite_test.go
+++ b/controllers/vmware/servicediscovery_controller_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package vmware
 
 import (
 	"context"

--- a/controllers/vmware/servicediscovery_controller_unit_test.go
+++ b/controllers/vmware/servicediscovery_controller_unit_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controllers
+package vmware
 
 import (
 	. "github.com/onsi/ginkgo/v2"

--- a/controllers/vmware/test/controllers_suite_test.go
+++ b/controllers/vmware/test/controllers_suite_test.go
@@ -64,7 +64,7 @@ func TestAPIs(t *testing.T) {
 	if artifactFolder, exists := os.LookupEnv("ARTIFACTS"); exists {
 		reporterConfig.JUnitReport = filepath.Join(artifactFolder, "junit.ginkgo.controllers_vmware_test.xml")
 	}
-	RunSpecs(t, "VMware Controller Suite", reporterConfig)
+	RunSpecs(t, "VMware Controller Suite test", reporterConfig)
 }
 
 func getTestEnv() (*envtest.Environment, *rest.Config) {

--- a/controllers/vmware/vspherecluster_reconciler_test.go
+++ b/controllers/vmware/vspherecluster_reconciler_test.go
@@ -18,13 +18,10 @@ package vmware
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +31,6 @@ import (
 	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -47,16 +43,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/services/vmoperator"
 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/util"
 )
-
-func TestVSphereClusterReconciler(t *testing.T) {
-	RegisterFailHandler(Fail)
-
-	reporterConfig := types.NewDefaultReporterConfig()
-	if artifactFolder, exists := os.LookupEnv("ARTIFACTS"); exists {
-		reporterConfig.JUnitReport = filepath.Join(artifactFolder, "junit.ginkgo.controllers_vmware.xml")
-	}
-	RunSpecs(t, "VSphereCluster Controller Suite", reporterConfig)
-}
 
 var _ = Describe("Cluster Controller Tests", func() {
 	const (
@@ -72,7 +58,6 @@ var _ = Describe("Cluster Controller Tests", func() {
 		cluster                  *clusterv1.Cluster
 		vsphereCluster           *vmwarev1.VSphereCluster
 		vsphereMachine           *vmwarev1.VSphereMachine
-		ctx                      = ctrl.SetupSignalHandler()
 		clusterCtx               *vmware.ClusterContext
 		controllerManagerContext *capvcontext.ControllerManagerContext
 		reconciler               *ClusterReconciler

--- a/controllers/vspherecluster_controller.go
+++ b/controllers/vspherecluster_controller.go
@@ -172,8 +172,3 @@ func clusterToInfrastructureMapFunc(ctx context.Context, controllerCtx *capvcont
 	gvk := infrav1.GroupVersion.WithKind(reflect.TypeOf(&infrav1.VSphereCluster{}).Elem().Name())
 	return clusterutilv1.ClusterToInfrastructureMapFunc(ctx, gvk, controllerCtx.Client, &infrav1.VSphereCluster{})
 }
-
-func clusterToVMwareInfrastructureMapFunc(ctx context.Context, controllerCtx *capvcontext.ControllerManagerContext) handler.MapFunc {
-	gvk := vmwarev1.GroupVersion.WithKind(reflect.TypeOf(&vmwarev1.VSphereCluster{}).Elem().Name())
-	return clusterutilv1.ClusterToInfrastructureMapFunc(ctx, gvk, controllerCtx.Client, &vmwarev1.VSphereCluster{})
-}

--- a/main.go
+++ b/main.go
@@ -408,11 +408,11 @@ func setupSupervisorControllers(ctx context.Context, controllerCtx *capvcontext.
 		return err
 	}
 
-	if err := controllers.AddServiceAccountProviderControllerToManager(ctx, controllerCtx, mgr, tracker, concurrency(providerServiceAccountConcurrency)); err != nil {
+	if err := vmware.AddServiceAccountProviderControllerToManager(ctx, controllerCtx, mgr, tracker, concurrency(providerServiceAccountConcurrency)); err != nil {
 		return err
 	}
 
-	return controllers.AddServiceDiscoveryControllerToManager(ctx, controllerCtx, mgr, tracker, concurrency(serviceDiscoveryConcurrency))
+	return vmware.AddServiceDiscoveryControllerToManager(ctx, controllerCtx, mgr, tracker, concurrency(serviceDiscoveryConcurrency))
 }
 
 func setupChecks(mgr ctrlmgr.Manager) {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!--  Thanks for sending a pull request! Please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api-provider-vsphere/CONTRIBUTING.md#contributing-a-patch), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other)
Here are some other tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Tests for https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/3179

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
