### PR TITLE
Bump Kubernetes version used for testing to v1.33.0-beta.0

### DIFF
--- a/test/e2e/config/vsphere.yaml
+++ b/test/e2e/config/vsphere.yaml
@@ -303,10 +303,10 @@ providers:
 
 variables:
   # Ensure all Kubernetes versions used here are covered in patch-vsphere-template.yaml
-  KUBERNETES_VERSION_MANAGEMENT: "v1.32.0"
-  KUBERNETES_VERSION: "v1.32.0"
-  KUBERNETES_VERSION_UPGRADE_FROM: "v1.31.0"
-  KUBERNETES_VERSION_UPGRADE_TO: "v1.32.0"
+  KUBERNETES_VERSION_MANAGEMENT: "v1.33.0-beta.0"
+  KUBERNETES_VERSION: "v1.33.0-beta.0"
+  KUBERNETES_VERSION_UPGRADE_FROM: "v1.32.0"
+  KUBERNETES_VERSION_UPGRADE_TO: "v1.33.0-beta.0"
   KUBERNETES_VERSION_LATEST_CI: "ci/latest-1.33"
   CPI_IMAGE_K8S_VERSION: "v1.32.1"
   CNI: "./data/cni/calico/calico.yaml"


### PR DESCRIPTION
Testing https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/3389